### PR TITLE
undef 'major' if it is defined in some header-file

### DIFF
--- a/control/harmony/Tonnetz.h
+++ b/control/harmony/Tonnetz.h
@@ -50,6 +50,11 @@
 // #include <cmath>
 #include <cstdlib>
 
+#ifdef major
+/* urgh: glibc defines 'major'... */
+# undef major
+#endif
+
 namespace jl {
 
 enum TonnetzDirection {


### PR DESCRIPTION
fixes a compilation error on GNU/linux (using glibc).
this is the relevant output of the compiler:

> warning: In the GNU C Library, "major" is defined
>  by <sys/sysmacros.h>. For historical compatibility, it is
>  currently defined by <sys/types.h> as well, but we plan to
>  remove this soon. To use "major", include <sys/sysmacros.h>
>  directly. If you did not intend to use a system-defined macro
>  "major", you should undefine it after including <sys/types.h>.

the <sys/types.h> header is included by <fstream> via <cstdlib>/<stdlib.h>